### PR TITLE
Replace freenode in example with libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ client.on("join", (msg) => {
   }
 });
 
-await client.connect("irc.freenode.net", 6667);
+await client.connect("irc.libera.chat", 6667);
 ```
 
 Note that this code above requires the `--allow-net` option.


### PR DESCRIPTION
https://libera.chat/ is the FLOSS successor of freenode.

https://www.devever.net/~hl/freenode_suicide
https://www.vice.com/en/article/m7ev8y/freenode-open-source-korea-crown-prince-takeover