### PR TITLE
Rewrite registration code (Implement SASL, separate acct/server passwords)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage
+.vscode

--- a/API.md
+++ b/API.md
@@ -1,6 +1,7 @@
 # API Reference
 
 - [Options](#options)
+  - [option: authMethod](#option-authmethod)
   - [option: bufferSize](#option-buffersize)
   - [option: channels](#option-channels)
   - [option: ctcpReplies](#option-ctcpreplies)
@@ -110,6 +111,33 @@ instance:
 const options = {/* available options are described below */};
 
 const client = new Client(options);
+```
+
+### option: authMethod
+
+The auth method to use with a supplied username and password. Defaults to
+NickServ if omitted.
+
+The authentication method to use.
+
+- `NickServ` - Non-standard nickserv authentication.
+- `sasl` - SASL PLAIN auth. Errors out if SASL fails.
+- `saslThenNickServ` - Try SASL PLAIN, but fallback to NickServ if it fails.
+
+```ts
+const client = new Client({
+  nick: "user", // will be used as username
+  password: "password",
+});
+```
+
+```ts
+const client = new Client({
+  nick: "user",
+  username: "SaslUser",
+  password: "password",
+  authMethod: "sasl",
+});
 ```
 
 ### option: bufferSize
@@ -235,7 +263,8 @@ const client = new Client({
 
 ### option: nick
 
-The nick used to register the client to the server.
+The nick used to register the client to the server. Will be reused as username
+for auth if no username is supplied.
 
 ```ts
 const client = new Client({
@@ -258,7 +287,7 @@ const client = new Client({
 
 ### option: password
 
-The password used to connect the client to the server.
+The password for the user account associated with the username field.
 
 ```ts
 const client = new Client({
@@ -324,6 +353,16 @@ const client = new Client({
   resolveInvalidNames: true,
 });
 ```
+
+### option: serverPassword
+
+```ts
+const client = new Client({
+  serverPassword: "password",
+});
+```
+
+An optional server password that will be sent via the PASS command.
 
 ### option: username
 

--- a/API.md
+++ b/API.md
@@ -14,6 +14,7 @@
   - [option: realname](#option-realname)
   - [option: reconnect](#option-reconnect)
   - [option: resolveInvalidNames](#option-resolveinvalidnames)
+  - [option: serverPassword](#option-serverpassword)
   - [option: username](#option-username)
   - [option: verbose](#option-verbose)
 - [Events](#events)

--- a/core/protocol.ts
+++ b/core/protocol.ts
@@ -169,7 +169,7 @@ const REPLIES = {
   "396": "rpl_hosthidden",
   "900": "rpl_loggedin",
   "901": "rpl_loggedout",
-  "903": "rpl_saslsuccess",
+  "903": "rpl_saslsuccess"
 } as const;
 
 const ERRORS = {
@@ -270,7 +270,7 @@ const ERRORS = {
   "904": "err_saslfail",
   "905": "err_sasltoolong",
   "906": "err_saslaborted",
-  "907": "err_saslalready",
+  "907": "err_saslalready"
 } as const;
 
 export const PROTOCOL = {

--- a/core/protocol.ts
+++ b/core/protocol.ts
@@ -169,7 +169,7 @@ const REPLIES = {
   "396": "rpl_hosthidden",
   "900": "rpl_loggedin",
   "901": "rpl_loggedout",
-  "903": "rpl_saslsuccess"
+  "903": "rpl_saslsuccess",
 } as const;
 
 const ERRORS = {
@@ -270,7 +270,7 @@ const ERRORS = {
   "904": "err_saslfail",
   "905": "err_sasltoolong",
   "906": "err_saslaborted",
-  "907": "err_saslalready"
+  "907": "err_saslalready",
 } as const;
 
 export const PROTOCOL = {

--- a/core/protocol.ts
+++ b/core/protocol.ts
@@ -1,5 +1,6 @@
 const COMMANDS = {
   "ADMIN": "admin",
+  "AUTHENTICATE": "authenticate",
   "AWAY": "away",
   "CAP": "cap",
   "CONNECT": "connect",
@@ -166,6 +167,9 @@ const REPLIES = {
   "394": "rpl_endofusers",
   "395": "rpl_nousers",
   "396": "rpl_hosthidden",
+  "900": "rpl_loggedin",
+  "901": "rpl_loggedout",
+  "903": "rpl_saslsuccess"
 } as const;
 
 const ERRORS = {
@@ -262,6 +266,11 @@ const ERRORS = {
   "550": "err_badhostmask",
   "551": "err_hostunavail",
   "552": "err_usingsline",
+  "902": "err_nicklocked",
+  "904": "err_saslfail",
+  "905": "err_sasltoolong",
+  "906": "err_saslaborted",
+  "907": "err_saslalready"
 } as const;
 
 export const PROTOCOL = {

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -84,19 +84,17 @@ export default createPlugin(
   // Sends capabilities, attempts SASL connection, and registers once connected.
   client.on("connected", () => {
     client.utils.sendCapabilities();
-    if (options.useSasl && !!password) {
-      client.cap("REQ", "sasl");
-      trySasl();
-      client.once("raw:rpl_saslsuccess", () => client.cap("END"));
-      client.once("raw:err_saslfail", () => sendRegistration());
-      client.once("raw:err_saslaborted", () => sendRegistration());
-    } else {
+    if (!options.useSasl || !password) {
       sendRegistration();
+      return;
     }
+
+    client.cap("REQ", "sasl");
+    trySasl();
+    client.once("raw:rpl_saslsuccess", () => client.cap("END"));
   });
 
   // Registers if receives ERR_NOTREGISTERED message
-
   client.on("raw:err_notregistered", () => {
     sendRegistration();
   });

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -27,7 +27,7 @@ interface RegistrationFeatures {
     /** Optional server password. */
     serverPassword?: string;
 
-    /** The authentication method to use.
+    /** The authentication method to use. Defaults to NickServ if omitted.
      * * `NickServ` - Non-standard nickserv authentication.
      * * `sasl` - SASL PLAIN auth. Errors out if SASL fails.
      * * `saslThenNickServ` - Try SASL PLAIN, but fallback to NickServ if it fails.

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -53,7 +53,6 @@ export default createPlugin(
     }
   }
 
-  // Resolves or rejects to denote if authenticating via sasl worked.
   const trySasl = () => {
     sendRegistration(false);
 

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -27,7 +27,7 @@ interface RegistrationFeatures {
     /** Whether we should use SASL to authenticate or not. */
     useSasl?: boolean;
 
-    /** SASL authentication mechanism to use. If unspecified, defaults to "PLAIN". 
+    /** SASL authentication mechanism to use. If unspecified, defaults to "PLAIN".
      * Currently, only PLAIN is supported.
     */
     saslType?: "PLAIN";
@@ -77,12 +77,12 @@ export default createPlugin(
 
   // Sends capabilities, attempts SASL connection, and registers once connected.
   client.on("connected", () => {
-    client.utils.sendCapabilities();
     if (options.useSasl) {
-      client.cap("REQ", "sasl");
-      trySasl().then(_ => client.cap("END")).catch(_ => sendRegistration());
+      client.utils.sendCapabilities("sasl");
+      trySasl().catch(_ => sendRegistration());
     }
     else {
+      client.utils.sendCapabilities();
       sendRegistration();
     }
   });

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -54,37 +54,32 @@ export default createPlugin(
 
   // Resolves or rejects to denote if authenticating via sasl worked.
   const trySasl = () => {
-    return new Promise(
-      (resolve: (_: void) => void, reject: (_: void) => void) => {
-        if (password === undefined) reject();
-        client.nick(nick);
-        client.user(username, realname);
+    client.nick(nick);
+    client.user(username, realname);
 
-        const capListener = (payload: Raw) => {
-          if (payload.params[2] !== "sasl") return;
-          client.send("AUTHENTICATE", options.saslType || "PLAIN");
-          client.off("raw:cap", capListener);
-        };
+    const capListener = (payload: Raw) => {
+      if (payload.params[2] !== "sasl") return;
+      client.send("AUTHENTICATE", options.saslType || "PLAIN");
+      client.off("raw:cap", capListener);
+    };
 
-        client.on("raw:cap", capListener);
-        client.once("raw:authenticate", (payload) => {
-          if (payload.params[0] === "+") {
-            client.send(
-              "AUTHENTICATE",
-              btoa(`${username}\x00${username}\x00${password}`),
-            );
-            client.once("raw:rpl_saslsuccess", () => resolve());
-          }
-        });
-      },
-    );
+    client.on("raw:cap", capListener);
+
+    client.once("raw:authenticate", (payload) => {
+      if (payload.params[0] === "+") {
+        client.send(
+          "AUTHENTICATE",
+          btoa(`${username}\x00${username}\x00${password}`),
+        );
+      }
+    });
   };
 
   // Sends capabilities, attempts SASL connection, and registers once connected.
   client.on("connected", () => {
-    if (options.useSasl) {
+    if (options.useSasl && password !== undefined) {
       client.utils.sendCapabilities("sasl");
-      trySasl().catch((_) => sendRegistration());
+      trySasl();
     } else {
       client.utils.sendCapabilities();
       sendRegistration();

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -67,7 +67,9 @@ export default createPlugin(
 
     client.once("raw:authenticate", (payload) => {
       if (payload.params[0] === "+") {
-        const chunked = [...chunks(btoa(`\x00${username}\x00${password}`), 400)];
+        const chunked = [
+          ...chunks(btoa(`\x00${username}\x00${password}`), 400),
+        ];
         for (let i = 0; i < chunked.length; i++) {
           const chunk = chunked[i];
           client.send("AUTHENTICATE", chunk);
@@ -77,7 +79,7 @@ export default createPlugin(
         }
       }
     });
-  }
+  };
 
   // Sends capabilities, attempts SASL connection, and registers once connected.
   client.on("connected", () => {

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -27,9 +27,9 @@ interface RegistrationFeatures {
     /** Whether we should use SASL to authenticate or not. */
     useSasl?: boolean;
 
-    /** SASL authentication mechanism to use. If unspecified, defaults to "PLAIN". 
+    /** SASL authentication mechanism to use. If unspecified, defaults to "PLAIN".
      * Currently, only PLAIN is supported.
-    */
+     */
     saslType?: "PLAIN";
   };
   state: {
@@ -54,35 +54,39 @@ export default createPlugin(
 
   // Resolves or rejects to denote if authenticating via sasl worked.
   const trySasl = () => {
-    return new Promise((resolve: (_: void) => void, reject: (_: void) => void) => {
-      if (password === undefined) reject();
-      client.nick(nick);
-      client.user(username, realname);
+    return new Promise(
+      (resolve: (_: void) => void, reject: (_: void) => void) => {
+        if (password === undefined) reject();
+        client.nick(nick);
+        client.user(username, realname);
 
-      const capListener = (payload: Raw) => {
-        if (payload.params[2] !== 'sasl') return;
-        client.send("AUTHENTICATE", options.saslType || "PLAIN");
-        client.off("raw:cap", capListener);
-      }
+        const capListener = (payload: Raw) => {
+          if (payload.params[2] !== "sasl") return;
+          client.send("AUTHENTICATE", options.saslType || "PLAIN");
+          client.off("raw:cap", capListener);
+        };
 
-      client.on("raw:cap", capListener);
-      client.once("raw:authenticate", (payload) => {
-        if (payload.params[0] === "+") {
-          client.send("AUTHENTICATE", btoa(`${username}\x00${username}\x00${password}`));
-          client.once("raw:rpl_saslsuccess", () => resolve());
-        }
-      })
-    })
-  }
+        client.on("raw:cap", capListener);
+        client.once("raw:authenticate", (payload) => {
+          if (payload.params[0] === "+") {
+            client.send(
+              "AUTHENTICATE",
+              btoa(`${username}\x00${username}\x00${password}`),
+            );
+            client.once("raw:rpl_saslsuccess", () => resolve());
+          }
+        });
+      },
+    );
+  };
 
   // Sends capabilities, attempts SASL connection, and registers once connected.
   client.on("connected", () => {
     client.utils.sendCapabilities();
     if (options.useSasl) {
       client.cap("REQ", "sasl");
-      trySasl().then(_ => client.cap("END")).catch(_ => sendRegistration());
-    }
-    else {
+      trySasl().then((_) => client.cap("END")).catch((_) => sendRegistration());
+    } else {
       sendRegistration();
     }
   });

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -27,7 +27,7 @@ interface RegistrationFeatures {
     /** Optional server password. */
     serverPassword?: string;
 
-    authMethod?: "NickServ" | "sasl" | "saslThenNickServ"
+    authMethod?: "NickServ" | "sasl" | "saslThenNickServ";
   };
   state: {
     user: User;
@@ -52,7 +52,7 @@ export default createPlugin(
     password,
   } = options;
 
-  const authMethod = options.authMethod || 'NickServ';
+  const authMethod = options.authMethod || "NickServ";
   client.state.user = { nick, username, realname };
 
   const sendRegistration = () => {
@@ -63,7 +63,7 @@ export default createPlugin(
 
   const tryNickServ = () => {
     client.send("PRIVMSG", "NickServ", `identify ${username} ${password}`);
-  }
+  };
 
   const trySasl = () => {
     const capListener = (payload: Raw) => {
@@ -94,10 +94,11 @@ export default createPlugin(
   client.on("connected", () => {
     sendRegistration();
     client.utils.sendCapabilities();
-    if (authMethod === 'NickServ') {
+
+    if (!password) return;
+    if (authMethod === "NickServ") {
       tryNickServ();
-    }
-    else {
+    } else {
       client.cap("REQ", "sasl");
       trySasl();
       client.once("raw:rpl_saslsuccess", () => client.cap("END"));
@@ -114,7 +115,7 @@ export default createPlugin(
 
   const onSaslFail = (_: Raw) => {
     client.cap("END");
-    if (authMethod === 'saslThenNickServ') tryNickServ();
+    if (authMethod === "saslThenNickServ") tryNickServ();
     else client.emitError("read", "ERROR: SASL auth failed", onSaslFail);
   };
 

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -97,8 +97,7 @@ export default createPlugin(
   client.on("connected", () => {
     client.utils.sendCapabilities();
     if (!useSasl || !password) {
-      sendRegistration();
-      return;
+      return sendRegistration();
     }
 
     client.cap("REQ", "sasl");
@@ -115,8 +114,10 @@ export default createPlugin(
   });
 
   const onSaslFail = (_: Raw) => {
-    if (tryPassOnSaslFail) sendRegistration();
-    else client.emitError("read", "ERROR: SASL auth failed", onSaslFail);
+    client.cap("END");
+    if (tryPassOnSaslFail && password) {
+      client.pass(password);
+    } else client.emitError("read", "ERROR: SASL auth failed", onSaslFail);
   };
   client.on(["raw:err_saslfail", "raw:err_saslaborted"], onSaslFail);
 

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -27,6 +27,11 @@ interface RegistrationFeatures {
     /** Optional server password. */
     serverPassword?: string;
 
+    /** The authentication method to use.
+     * * `NickServ` - Non-standard nickserv authentication.
+     * * `sasl` - SASL PLAIN auth. Errors out if SASL fails.
+     * * `saslThenNickServ` - Try SASL PLAIN, but fallback to NickServ if it fails.
+     */
     authMethod?: "NickServ" | "sasl" | "saslThenNickServ";
   };
   state: {

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -47,7 +47,7 @@ export default createPlugin(
     client.user(username, realname);
   };
 
-  function* chunks<T>(str: string, n: number): Generator<string, void> {
+  function* chunks(str: string, n: number): Generator<string, void> {
     for (let i = 0; i < str.length; i += n) {
       yield str.slice(i, i + n);
     }

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -80,13 +80,15 @@ export default createPlugin(
     })
   }
 
-  // Sends capabilities and registers once connected.
-
+  // Sends capabilities, attempts SASL connection, and registers once connected.
   client.on("connected", () => {
     if (options.useSasl) {
-      client.utils.sendCapabilities("sasl");
-      trySasl().then(_ => { }).catch(_ => {
-        // fall back to SASL gracefully
+      client.cap("REQ", "sasl");
+      trySasl().then(_ => {
+        client.cap("END");
+        client.utils.sendCapabilities();
+      }).catch(_ => {
+        client.utils.sendCapabilities();
         sendRegistration();
       })
     }

--- a/plugins/registration.ts
+++ b/plugins/registration.ts
@@ -61,7 +61,7 @@ export default createPlugin(
     password,
   } = options;
 
-  const authMethod = options.authMethod || "NickServ";
+  const authMethod = options.authMethod ?? "NickServ";
   client.state.user = { nick, username, realname };
 
   const sendRegistration = () => {

--- a/plugins/registration_test.ts
+++ b/plugins/registration_test.ts
@@ -74,7 +74,7 @@ describe("plugins/registration", (test) => {
     await client.once("raw:authenticate");
 
     assertEquals(server.receive(), [
-      "AUTHENTICATE dXNlcgB1c2VyAHBhc3N3b3Jk",
+      "AUTHENTICATE AHVzZXIAcGFzc3dvcmQ=",
     ]);
 
     server.send([

--- a/plugins/registration_test.ts
+++ b/plugins/registration_test.ts
@@ -57,8 +57,8 @@ describe("plugins/registration", (test) => {
 
     assertEquals(raw, [
       "CAP REQ multi-prefix",
-      "CAP REQ sasl",
       "CAP END",
+      "CAP REQ sasl",
       "NICK me",
       "USER user 0 * :real name",
     ]);

--- a/plugins/registration_test.ts
+++ b/plugins/registration_test.ts
@@ -6,12 +6,29 @@ describe("plugins/registration", (test) => {
   const options = {
     username: "user",
     realname: "real name",
-    password: "password",
   };
 
   test("register on connect", async () => {
     const { client, server } = await mock(
       options,
+      { withConnection: false },
+    );
+
+    (client.state as { capabilities: typeof client.state.capabilities })
+      .capabilities = [];
+
+    await client.connect("");
+    const raw = server.receive();
+
+    assertEquals(raw, [
+      "NICK me",
+      "USER user 0 * :real name",
+    ]);
+  });
+
+  test("send server password if supplied", async () => {
+    const { client, server } = await mock(
+      { ...options, serverPassword: "password" },
       { withConnection: false },
     );
 
@@ -38,17 +55,32 @@ describe("plugins/registration", (test) => {
     const raw = server.receive();
 
     assertEquals(raw, [
-      "CAP REQ multi-prefix",
-      "CAP END",
-      "PASS password",
       "NICK me",
       "USER user 0 * :real name",
+      "CAP REQ multi-prefix",
+      "CAP END",
     ]);
   });
 
-  test("send sasl capability sequence", async () => {
+  test("use nickserv auth when password supplied", async () => {
     const { client, server } = await mock(
-      { ...options, useSasl: true },
+      { ...options, password: "password" },
+    );
+
+    await client.connect("");
+    const raw = server.receive();
+    assertEquals(raw, [
+      "NICK me",
+      "USER user 0 * :real name",
+      "CAP REQ multi-prefix",
+      "CAP END",
+      "PRIVMSG NickServ :identify user password",
+    ]);
+  });
+
+  test("send sasl capability sequence if password supplied and authMethod is sasl", async () => {
+    const { client, server } = await mock(
+      { ...options, password: "password", authMethod: "sasl" },
       { withConnection: false },
     );
 
@@ -56,11 +88,11 @@ describe("plugins/registration", (test) => {
     const raw = server.receive();
 
     assertEquals(raw, [
+      "NICK me",
+      "USER user 0 * :real name",
       "CAP REQ multi-prefix",
       "CAP END",
       "CAP REQ sasl",
-      "NICK me",
-      "USER user 0 * :real name",
     ]);
 
     server.send(":serverhost CAP me ACK :sasl");
@@ -94,7 +126,6 @@ describe("plugins/registration", (test) => {
     const raw = server.receive();
 
     assertEquals(raw, [
-      "PASS password",
       "NICK me",
       "USER user 0 * :real name",
     ]);


### PR DESCRIPTION
As far as I can tell, Libera requires certain IP ranges (such as those used by DigitalOcean) to authenticate via SASL. This is troublesome for bots, so I've put together a quick draft of SASL PLAIN support for this library. I've extended the existing registration.ts code with a boolean option "useSasl". If this is set to true, the client tries SASL auth first and failing that reverts to using PASS. Would love to hear thoughts.