### PR TITLE
chore(ci): run CI only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: ci
 
 on:
   pull_request:
+    branches:
+      - "*"
   push:
-    branches: main
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   pull_request:
     branches:
-      - "*"
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: main
 
 jobs:
   test:


### PR DESCRIPTION
Runs Github actions only when a pull request is open or when commits are pushed to `main`.