### PR TITLE
feat(plugins/verbose): add "raw", "formatted" and custom logger impl

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -1,0 +1,18 @@
+import { Client } from "./mod.ts";
+
+const client = new Client({
+  nick: "totoche",
+  verbose: (log) => {
+    if (log.type === "event") {
+      if (log.event === "join") {
+        log.payload;
+      } else if (log.event === "fdfdfs") {
+        log.payload;
+      }
+    }
+  },
+});
+
+client.connect("irc.libera.chat");
+
+client.on("")

--- a/deps.ts
+++ b/deps.ts
@@ -5,11 +5,10 @@ export {
   red,
   stripColor,
 } from "https://deno.land/std@0.203.0/fmt/colors.ts";
-export {
-  assertArrayIncludes,
-  assertEquals,
-  assertExists,
-  assertMatch,
-  assertRejects,
-  assertThrows,
-} from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+export { assertArrayIncludes } from "https://deno.land/std@0.203.0/assert/assert_array_includes.ts";
+export { assertEquals } from "https://deno.land/std@0.203.0/assert/assert_equals.ts";
+export { assertExists } from "https://deno.land/std@0.203.0/assert/assert_exists.ts";
+export { assertMatch } from "https://deno.land/std@0.203.0/assert/assert_match.ts";
+export { assertRejects } from "https://deno.land/std@0.203.0/assert/assert_rejects.ts";
+export { assertThrows } from "https://deno.land/std@0.203.0/assert/assert_throws.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -4,7 +4,7 @@ export {
   green,
   red,
   stripColor,
-} from "https://deno.land/std@0.202.0/fmt/colors.ts";
+} from "https://deno.land/std@0.203.0/fmt/colors.ts";
 export {
   assertArrayIncludes,
   assertEquals,
@@ -12,4 +12,4 @@ export {
   assertMatch,
   assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.202.0/testing/asserts.ts";
+} from "https://deno.land/std@0.203.0/testing/asserts.ts";

--- a/plugins/verbose.ts
+++ b/plugins/verbose.ts
@@ -1,72 +1,150 @@
+import { CoreClient } from "../core/client.ts";
 import { type ClientError } from "../core/errors.ts";
 import { createPlugin } from "../core/plugins.ts";
+import { type AnyRawCommand } from "../core/protocol.ts";
 import { bold, dim, green, red } from "../deps.ts";
+
+interface RawLogPayload {
+  type: "raw_input" | "raw_output";
+  msg: string | null;
+}
+
+interface EventLogPayload {
+  type: "event";
+  event: string;
+  payload: unknown;
+}
+
+interface CommandLogPayload {
+  type: "command";
+  command: AnyRawCommand;
+  params: (string | undefined)[];
+}
+
+interface StateLogPayload {
+  type: "state";
+  state: CoreClient["state"];
+  key: keyof CoreClient["state"];
+  value: unknown;
+}
+
+type LogPayload =
+  | RawLogPayload
+  | EventLogPayload
+  | CommandLogPayload
+  | StateLogPayload;
+
+type LoggerImpl = (payload: LogPayload) => void;
 
 interface VerboseFeatures {
   options: {
-    /** Prints informations to output. */
-    verbose?: boolean;
+    /** Prints informations to output.
+     *
+     * - `"raw"`: received and sent raw IRC messages
+     * - `"formatted"`: formatted events, commands and state changes
+     * - `(payload: LogPayload) => void`: a custom logger implementation */
+    verbose?: "raw" | "formatted" | LoggerImpl;
   };
 }
 
-const DEFAULT_VERBOSE = false;
+// Default logger used with "raw" verbose value
+const defaultRawLogger: LoggerImpl = (payload) => {
+  switch (payload.type) {
+    case "raw_input": { // Prints received raw messages
+      if (payload.msg !== null) {
+        console.info(
+          dim("read"),
+          dim(bold("chunks")),
+          dim(JSON.stringify(payload.msg)),
+        );
+      }
+      break;
+    }
+
+    case "raw_output": { // Prints sent raw messages
+      if (payload.msg !== null) {
+        console.info(
+          dim("send"),
+          dim(bold("raw")),
+          dim(JSON.stringify(payload.msg)),
+        );
+      }
+      break;
+    }
+  }
+};
+
+// Default logger used with "formatted" verbose value
+const defaultFormattedLogger: LoggerImpl = (payload) => {
+  switch (payload.type) {
+    case "event": { // Prints emitted events
+      if (payload.event.startsWith("raw")) {
+        return;
+      }
+      if (payload.event === "error") {
+        const { type, name, message } = payload.payload as ClientError;
+        payload.payload = { type, name, message };
+      }
+      console.info("emit", bold(payload.event), payload.payload);
+      break;
+    }
+
+    case "command": { // Prints sent commands
+      console.info("send", bold(payload.command), payload.params);
+      break;
+    }
+
+    case "state": { // Prints state changes
+      const prev = JSON.stringify(payload.state[payload.key]);
+      const next = JSON.stringify(payload.value);
+      const label = bold(payload.key.toString());
+
+      if (prev !== next) {
+        console.info("diff", label, red(`- ${prev}`));
+        console.info("diff", label, green(`+ ${next}`));
+      }
+      break;
+    }
+  }
+};
 
 export default createPlugin(
   "verbose",
 )<VerboseFeatures>((client, options) => {
-  const enabled = options.verbose ?? DEFAULT_VERBOSE;
-  if (!enabled) return;
+  const getLoggerImpl = () => {
+    switch (options.verbose) {
+      case "raw":
+        return defaultRawLogger;
+      case "formatted":
+        return defaultFormattedLogger;
+      case undefined:
+        return undefined;
+      default:
+        return options.verbose;
+    }
+  };
 
-  // Prints received messages.
+  const loggerImpl = getLoggerImpl();
+  if (!loggerImpl) return;
 
   // deno-lint-ignore no-explicit-any
   client.hooks.afterCall("read" as any, (chunks: string | null) => {
-    if (chunks !== null) {
-      console.info(
-        dim("read"),
-        dim(bold("chunks")),
-        dim(JSON.stringify(chunks)),
-      );
-    }
+    loggerImpl({ type: "raw_input", msg: chunks });
   });
-
-  // Prints sent messages.
 
   client.hooks.afterCall("send", (raw) => {
-    if (raw !== null) {
-      console.info(dim("send"), dim(bold("raw")), dim(JSON.stringify(raw)));
-    }
+    loggerImpl({ type: "raw_output", msg: raw });
   });
-
-  // Prints sent commands.
 
   client.hooks.beforeCall("send", (command, ...params) => {
-    console.info("send", bold(command), params);
+    loggerImpl({ type: "command", command, params });
   });
-
-  // Prints emitted events.
 
   client.hooks.beforeCall("emit", (event, payload) => {
-    if (event.startsWith("raw")) {
-      return;
-    }
-    if (event === "error") {
-      const { type, name, message } = payload as ClientError;
-      payload = { type, name, message };
-    }
-    console.info("emit", bold(event), payload);
+    loggerImpl({ type: "event", event, payload });
   });
 
-  // Prints state changes.
-
   client.hooks.beforeMutate("state", (state, key, value) => {
-    const prev = JSON.stringify(state[key]);
-    const next = JSON.stringify(value);
-    const label = bold(key.toString());
-
-    if (prev !== next) {
-      console.info("diff", label, red(`- ${prev}`));
-      console.info("diff", label, green(`+ ${next}`));
-    }
+    loggerImpl({ type: "state", state, key, value });
   });
 });

--- a/plugins/verbose.ts
+++ b/plugins/verbose.ts
@@ -1,4 +1,4 @@
-import { CoreClient } from "../core/client.ts";
+// deno-lint-ignore-file no-explicit-any
 import { type ClientError } from "../core/errors.ts";
 import { createPlugin } from "../core/plugins.ts";
 import { type AnyRawCommand } from "../core/protocol.ts";
@@ -12,7 +12,7 @@ interface RawLogPayload {
 interface EventLogPayload {
   type: "event";
   event: string;
-  payload: unknown;
+  payload: any;
 }
 
 interface CommandLogPayload {
@@ -23,9 +23,9 @@ interface CommandLogPayload {
 
 interface StateLogPayload {
   type: "state";
-  state: CoreClient["state"];
-  key: keyof CoreClient["state"];
-  value: unknown;
+  state: any;
+  key: string;
+  value: any;
 }
 
 type LogPayload =
@@ -127,7 +127,6 @@ export default createPlugin(
   const loggerImpl = getLoggerImpl();
   if (!loggerImpl) return;
 
-  // deno-lint-ignore no-explicit-any
   client.hooks.afterCall("read" as any, (chunks: string | null) => {
     loggerImpl({ type: "raw_input", msg: chunks });
   });


### PR DESCRIPTION
This PR adds two built-in logger and custom impl logger.

`raw` built-in logger:

```ts
new Client({
  verbose: "raw"
})
```

`formatted` built-in logger:

```ts
new Client({
  verbose: "formatted"
})
```

Custom impl logger:

```ts
new Client({
  verbose: (payload) => {
    if (payload.type === "raw_input" || payload.type === "raw_output") {
      console.log(payload.msg)
    }

    if (payload.type === "command") {
      console.log(payload.command, payload.params)
    }

    if (payload.type === "event") {
      ...
    }

    ...
  }
})
```

not sure about naming of these parts (payload, log, verbose, etc.)