### PR TITLE
add exponential backoff option to reconnect plugin

### DIFF
--- a/API.md
+++ b/API.md
@@ -335,7 +335,7 @@ const client = new Client({
 
 Enables auto reconnect.
 
-Takes boolean or `{ attempts?: number, delay?: number }`.
+Takes a boolean or `{ attempts?: number, delay?: number, exponentialBackoff?: boolean }`.
 
 Default to `false` or `{ attempts: 10, delay: 5 }` if set to `true`.
 
@@ -354,6 +354,18 @@ const client = new Client({
   reconnect: {
     attempts: 3,
     delay: 10,
+  },
+});
+```
+
+Tries to reconnect `5` times with an initial delay of `3` seconds with an exponential backoff:
+
+```ts
+const client = new Client({
+  reconnect: {
+    attempts: 5,
+    delay: 3,
+    exponentialBackoff: true,
   },
 });
 ```

--- a/deps.ts
+++ b/deps.ts
@@ -4,13 +4,13 @@ export {
   green,
   red,
   stripColor,
-} from "https://deno.land/std@0.203.0/fmt/colors.ts";
+} from "https://deno.land/std@0.224.0/fmt/colors.ts";
 
-export { assertArrayIncludes } from "https://deno.land/std@0.203.0/assert/assert_array_includes.ts";
-export { assertEquals } from "https://deno.land/std@0.203.0/assert/assert_equals.ts";
-export { assertExists } from "https://deno.land/std@0.203.0/assert/assert_exists.ts";
-export { assertMatch } from "https://deno.land/std@0.203.0/assert/assert_match.ts";
-export { assertRejects } from "https://deno.land/std@0.203.0/assert/assert_rejects.ts";
-export { assertThrows } from "https://deno.land/std@0.203.0/assert/assert_throws.ts";
+export { assertArrayIncludes } from "https://deno.land/std@0.224.0/assert/assert_array_includes.ts";
+export { assertEquals } from "https://deno.land/std@0.224.0/assert/assert_equals.ts";
+export { assertExists } from "https://deno.land/std@0.224.0/assert/assert_exists.ts";
+export { assertMatch } from "https://deno.land/std@0.224.0/assert/assert_match.ts";
+export { assertRejects } from "https://deno.land/std@0.224.0/assert/assert_rejects.ts";
+export { assertThrows } from "https://deno.land/std@0.224.0/assert/assert_throws.ts";
 
 export { Queue } from "https://deno.land/x/queue@1.2.0/mod.ts";

--- a/plugins/antiflood_test.ts
+++ b/plugins/antiflood_test.ts
@@ -4,7 +4,7 @@ import { mock } from "../testing/mock.ts";
 
 describe("plugins/antiflood", (test) => {
   test("send two PRIVMSG with delay", async () => {
-    const { client, server } = await mock({ floodDelay: 250 });
+    const { client, server } = await mock({ floodDelay: 10 });
 
     client.privmsg("#channel", "Hello world");
     client.privmsg("#channel", "Hello world, again");
@@ -16,7 +16,7 @@ describe("plugins/antiflood", (test) => {
     ]);
 
     // Wait for second message to make it through
-    await delay(1000);
+    await delay(100);
     raw = server.receive();
 
     // Second message now dispatched to server

--- a/plugins/reconnect_test.ts
+++ b/plugins/reconnect_test.ts
@@ -19,6 +19,8 @@ describe("plugins/reconnect", (test) => {
     await client.once("reconnecting");
 
     assertEquals(reconnecting, 1);
+
+    await client.once("error"); // wait for timeout clearing
   });
 
   test("reconnect on server error", async () => {
@@ -36,6 +38,8 @@ describe("plugins/reconnect", (test) => {
     await client.once("reconnecting");
 
     assertEquals(reconnecting, 1);
+
+    await client.once("connecting"); // wait for timeout clearing
   });
 
   test("reset attemps when RPL_WELCOME is received", async () => {
@@ -67,6 +71,8 @@ describe("plugins/reconnect", (test) => {
     await client.once("reconnecting");
 
     assertEquals(reconnecting, 3);
+
+    await client.once("connecting"); // wait for timeout clearing
   });
 
   test("not reconnect if disabled", async () => {

--- a/testing/conn.ts
+++ b/testing/conn.ts
@@ -61,4 +61,6 @@ export class MockConn extends EventEmitter<Events> implements Deno.Conn {
   ref(): void {}
 
   unref(): void {}
+
+  [Symbol.dispose](): void {}
 }


### PR DESCRIPTION
This following adds an exponential backoff option to the reconnect plugin (thanks to [@tio](https://github.com/tionis) for the idea).

Fix https://github.com/jeromeludmann/deno-irc/issues/14